### PR TITLE
send arrays of objects as is

### DIFF
--- a/component.json
+++ b/component.json
@@ -9,12 +9,9 @@
     "segmentio/alias": "0.2.1",
     "segmentio/convert-dates": "0.1.0",
     "segmentio/obj-case": "0.2.1",
-    "component/each": "0.0.1",
     "ndhoule/includes": "^1.0.0",
     "segmentio/analytics.js-integration": "^1.0.0",
-    "ianstormtaylor/is": "0.1.0",
-    "segmentio/to-iso-string": "0.0.1",
-    "yields/some": "1.0.0"
+    "segmentio/to-iso-string": "0.0.1"
   },
   "development": {
     "segmentio/analytics.js-core": "^2.10.0",

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,12 +6,9 @@
 var alias = require('alias');
 var dates = require('convert-dates');
 var del = require('obj-case').del;
-var each = require('each');
 var includes = require('includes');
 var integration = require('analytics.js-integration');
-var is = require('is');
 var iso = require('to-iso-string');
-var some = require('some');
 
 /**
  * Expose `Mixpanel` integration.
@@ -170,11 +167,6 @@ Mixpanel.prototype.track = function(track) {
   delete props.mp_name_tag;
   delete props.mp_note;
   delete props.token;
-
-  // convert arrays of objects to length, since mixpanel doesn't support object arrays
-  each(props, function(key, val) {
-    if (is.array(val) && some(val, is.object)) props[key] = val.length;
-  });
 
   // increment properties in mixpanel people
   if (people && includes(increment, increments)) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -304,11 +304,6 @@ describe('Mixpanel', function() {
         analytics.called(window.mixpanel.track, 'event', { array: [13, 28, 99] });
       });
 
-      it('should convert arrays of objects to lengths', function() {
-        analytics.track('event', { array: [{ a: 'asdf' }, { b: 'geasd' }, { c: 'asfee' }] });
-        analytics.called(window.mixpanel.track, 'event', { array: 3 });
-      });
-
       it('should remove mixpanel\'s reserved properties', function() {
         analytics.track('event', {
           distinct_id: 'string',


### PR DESCRIPTION
ticket ref: https://segment.zendesk.com/agent/tickets/31289

Mixpanel is not good with arrays but they will still accept them and convert them to a string on their end.
This allows users to segment and filter their properties using the `contains` function. 

So took out the part where we convert arrays of object to the length of the array.

Rep from Mixpanel:

"You can pass arrays into Mixpanel, but it will interpret them as strings. Here is an example from a sample project. As you can see, you can segment the event using the 'contains' function, but you cannot segment by one of the nested properties within the array: 
https://www.dropbox.com/s/f4pdzfce5815mso/Screenshot%202015-07-29%2010.02.47.png?dl=0 
I would suggest checking with Segment to determine why they are sending a value of one for a property where you specified an array value. It could well be that Segment does this because it knows that Mixpanel doesn't handle arrays too well, but maybe they have a workaround on their end to send the array."

@ndhoule @f2prateek 