### PR TITLE
refactor enhancedTrack :100:

### DIFF
--- a/component.json
+++ b/component.json
@@ -10,6 +10,8 @@
     "segmentio/convert-dates": "0.1.0",
     "segmentio/obj-case": "0.2.1",
     "ndhoule/includes": "^1.0.0",
+    "ndhoule/pick": "^1.0.0",
+    "ianstormtaylor/is": "0.1.1",
     "segmentio/analytics.js-integration": "^1.0.0",
     "segmentio/to-iso-string": "0.0.1"
   },

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,8 @@ var del = require('obj-case').del;
 var includes = require('includes');
 var integration = require('analytics.js-integration');
 var iso = require('to-iso-string');
+var pick = require('pick');
+var is = require('is');
 
 /**
  * Expose `Mixpanel` integration.
@@ -17,7 +19,6 @@ var iso = require('to-iso-string');
 var Mixpanel = module.exports = integration('Mixpanel')
   .global('mixpanel')
   .option('increments', [])
-  .option('enhancedTrack', false)
   .option('cookieName', '')
   .option('crossSubdomainCookie', false)
   .option('secureCookie', false)
@@ -25,6 +26,7 @@ var Mixpanel = module.exports = integration('Mixpanel')
   .option('pageview', false)
   .option('people', false)
   .option('token', '')
+  .option('setAllTraitsByDefault', true)
   .option('trackAllPages', false)
   .option('trackNamedPages', true)
   .option('trackCategorizedPages', true)
@@ -130,6 +132,7 @@ Mixpanel.prototype.identify = function(identify) {
   var username = identify.username();
   var email = identify.email();
   var id = identify.userId();
+  var setAllTraitsByDefault = this.options.setAllTraitsByDefault;
 
   // id
   if (id) window.mixpanel.identify(id);
@@ -138,11 +141,21 @@ Mixpanel.prototype.identify = function(identify) {
   var nametag = email || username || id;
   if (nametag) window.mixpanel.name_tag(nametag);
 
-  // traits
+  // default set all traits as super and people properties
   var traits = identify.traits(traitAliases);
   if (traits.$created) del(traits, 'createdAt');
-  window.mixpanel.register(dates(traits, iso));
-  if (this.options.people) window.mixpanel.people.set(traits);
+  if (setAllTraitsByDefault) {
+    window.mixpanel.register(dates(traits, iso));
+    if (this.options.people) window.mixpanel.people.set(traits);
+  }
+
+  // explicitly set select traits as people and super properties
+  var opts = identify.integrations() || {};
+  opts = opts[this.name];
+  var superProps = pick(opts.superProperties || [], traits);
+  var peopleProps = pick(opts.peopleProperties || [], traits);
+  if (!is.empty(superProps)) window.mixpanel.register(superProps);
+  if (!is.empty(peopleProps)) window.mixpanel.people.set(peopleProps);
 };
 
 /**
@@ -159,11 +172,11 @@ Mixpanel.prototype.track = function(track) {
   var increments = this.options.increments;
   var increment = track.event().toLowerCase();
   var people = this.options.people;
-  var enhancedTrack = this.options.enhancedTrack;
   var props = track.properties();
-  var superProps = props.super;
-  var peopleProps = props.people;
   var revenue = track.revenue();
+  var opts = track.options(this.name) || {};
+  var superProps = pick(opts.superProperties || [], props);
+  var peopleProps = pick(opts.peopleProperties || [], props);
 
   // delete mixpanel's reserved properties, so they don't conflict
   delete props.distinct_id;
@@ -182,13 +195,13 @@ Mixpanel.prototype.track = function(track) {
   props = dates(props, iso);
   window.mixpanel.track(track.event(), props);
 
-  // register super properties for enhancedTrack
-  if (enhancedTrack && typeof superProps === 'object') {
+  // register super properties if present in context.mixpanel.superProperties
+  if (!is.empty(superProps)) {
     window.mixpanel.register(superProps);
   }
 
-  // set people properties for enhancedTrack
-  if (enhancedTrack && typeof peopleProps === 'object') {
+  // set people properties if present in context.mixpanel.peopleProperties
+  if (!is.empty(peopleProps)) {
     window.mixpanel.people.set(peopleProps);
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -40,10 +40,10 @@ describe('Mixpanel', function() {
       .option('nameTag', true)
       .option('pageview', false)
       .option('people', false)
-      .option('enhancedTrack', false)
       .option('token', '')
       .option('trackAllPages', false)
-      .option('trackNamedPages', true));
+      .option('trackNamedPages', true)
+      .option('setAllTraitsByDefault', true));
   });
 
   describe('before loading', function() {
@@ -176,6 +176,28 @@ describe('Mixpanel', function() {
         analytics.called(window.mixpanel.people.set, { trait: true });
       });
 
+      it('should set super properties from the context.mixpanel.superProperties object if setAllTraitsByDefault is false', function() {
+        mixpanel.options.setAllTraitsByDefault = false;
+        analytics.identify(123, { accountStatus: 'Paid', subscribed: true }, { Mixpanel: { superProperties: ['accountStatus', 'subscribed'] } });
+        analytics.called(window.mixpanel.identify, 123);
+        analytics.called(window.mixpanel.register, { accountStatus: 'Paid', subscribed: true });
+      });
+
+      it('should set people properties from the context.mixpanel.peopleProperties object if setAllTraitsByDefault is false', function() {
+        mixpanel.options.people = false;
+        mixpanel.options.setAllTraitsByDefault = true;
+        analytics.identify(123, { friend: 'elmo' }, { Mixpanel: { peopleProperties: ['friend'] } });
+        analytics.called(window.mixpanel.identify, 123);
+        analytics.called(window.mixpanel.people.set, { friend: 'elmo' });
+      });
+
+      it('shouldn\'t set people properties from the context.mixpanel.peopleProperties object if setAllTraitsByDefault is false', function() {
+        mixpanel.options.people = false;
+        mixpanel.options.setAllTraitsByDefault = false;
+        analytics.identify(123, { friend: 'elmo' });
+        analytics.called(window.mixpanel.identify, 123);
+      });
+
       it('should alias traits', function() {
         var date = new Date();
         analytics.identify({
@@ -276,16 +298,14 @@ describe('Mixpanel', function() {
         analytics.called(window.mixpanel.people.track_charge, 9.99);
       });
 
-      it('should set super properties from the props.super object', function() {
-        mixpanel.options.enhancedTrack = true;
-        analytics.track('event', { super: { 'Account Status': 'Paid' } });
-        analytics.called(window.mixpanel.register, { 'Account Status': 'Paid' });
+      it('should set super properties from the context.mixpanel.superProperties object', function() {
+        analytics.track('event', { accountStatus: 'Paid', subscribed: true }, { Mixpanel: { superProperties: ['accountStatus', 'subscribed'] } });
+        analytics.called(window.mixpanel.register, { accountStatus: 'Paid', subscribed: true });
       });
 
-      it('should set people properties from the props.people object', function() {
+      it('should set people properties from the context.mixpanel.peopleProperties object', function() {
         mixpanel.options.people = true;
-        mixpanel.options.enhancedTrack = true;
-        analytics.track('event', { people: { friend: 'elmo' } });
+        analytics.track('event', { friend: 'elmo' }, { Mixpanel: { peopleProperties: ['friend'] } });
         analytics.called(window.mixpanel.people.set, { friend: 'elmo' });
       });
 


### PR DESCRIPTION
removed the enhancedTrack option and instead pull the people and super property keys from context.mixpanel object. I've placed this behind a flag, `setExplicit` that will allow customers to explicitly set people and super Properties on both track and identify calls. This flag will also keep the identify call from setting the traits as both people and super properties.