### PR TITLE
Allow explicit declaration of people/super properties

### DIFF
--- a/component.json
+++ b/component.json
@@ -10,6 +10,8 @@
     "segmentio/convert-dates": "0.1.0",
     "segmentio/obj-case": "0.2.1",
     "ndhoule/includes": "^1.0.0",
+    "ndhoule/pick": "^1.0.0",
+    "ianstormtaylor/is": "0.1.1",
     "segmentio/analytics.js-integration": "^1.0.0",
     "segmentio/to-iso-string": "0.0.1"
   },

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,8 @@ var del = require('obj-case').del;
 var includes = require('includes');
 var integration = require('analytics.js-integration');
 var iso = require('to-iso-string');
+var pick = require('pick');
+var is = require('is');
 
 /**
  * Expose `Mixpanel` integration.
@@ -17,7 +19,6 @@ var iso = require('to-iso-string');
 var Mixpanel = module.exports = integration('Mixpanel')
   .global('mixpanel')
   .option('increments', [])
-  .option('enhancedTrack', false)
   .option('cookieName', '')
   .option('crossSubdomainCookie', false)
   .option('secureCookie', false)
@@ -25,6 +26,7 @@ var Mixpanel = module.exports = integration('Mixpanel')
   .option('pageview', false)
   .option('people', false)
   .option('token', '')
+  .option('setAllTraitsByDefault', true)
   .option('trackAllPages', false)
   .option('trackNamedPages', true)
   .option('trackCategorizedPages', true)
@@ -130,6 +132,7 @@ Mixpanel.prototype.identify = function(identify) {
   var username = identify.username();
   var email = identify.email();
   var id = identify.userId();
+  var setAllTraitsByDefault = this.options.setAllTraitsByDefault;
 
   // id
   if (id) window.mixpanel.identify(id);
@@ -138,11 +141,21 @@ Mixpanel.prototype.identify = function(identify) {
   var nametag = email || username || id;
   if (nametag) window.mixpanel.name_tag(nametag);
 
-  // traits
+  // default set all traits as super and people properties
   var traits = identify.traits(traitAliases);
   if (traits.$created) del(traits, 'createdAt');
-  window.mixpanel.register(dates(traits, iso));
-  if (this.options.people) window.mixpanel.people.set(traits);
+  if (setAllTraitsByDefault) {
+    window.mixpanel.register(dates(traits, iso));
+    if (this.options.people) window.mixpanel.people.set(traits);
+  }
+
+  // explicitly set select traits as people and super properties
+  var opts = identify.integrations() || {};
+  opts = opts[this.name];
+  var superProps = pick(opts.superProperties || [], traits);
+  var peopleProps = pick(opts.peopleProperties || [], traits);
+  if (!is.empty(superProps)) window.mixpanel.register(superProps);
+  if (!is.empty(peopleProps)) window.mixpanel.people.set(peopleProps);
 };
 
 /**
@@ -159,11 +172,11 @@ Mixpanel.prototype.track = function(track) {
   var increments = this.options.increments;
   var increment = track.event().toLowerCase();
   var people = this.options.people;
-  var enhancedTrack = this.options.enhancedTrack;
   var props = track.properties();
-  var superProps = props.super;
-  var peopleProps = props.people;
   var revenue = track.revenue();
+  var opts = track.options(this.name) || {};
+  var superProps = pick(opts.superProperties || [], props);
+  var peopleProps = pick(opts.peopleProperties || [], props);
 
   // delete mixpanel's reserved properties, so they don't conflict
   delete props.distinct_id;
@@ -182,13 +195,13 @@ Mixpanel.prototype.track = function(track) {
   props = dates(props, iso);
   window.mixpanel.track(track.event(), props);
 
-  // register super properties for enhancedTrack
-  if (enhancedTrack && typeof superProps === 'object') {
+  // register super properties if present in context.mixpanel.superProperties
+  if (!is.empty(superProps)) {
     window.mixpanel.register(superProps);
   }
 
-  // set people properties for enhancedTrack
-  if (enhancedTrack && typeof peopleProps === 'object') {
+  // set people properties if present in context.mixpanel.peopleProperties
+  if (!is.empty(peopleProps)) {
     window.mixpanel.people.set(peopleProps);
   }
 


### PR DESCRIPTION
This change does not affect default behavior; as long as a user has "Automatically set all Traits as Super Properties and People Properties" checked in our UI (which it is by default), the integration will behave as it always has, setting all traits to super properties and all traits to People Properties if "Use Mixpanel People" is enabled as well.

However, this change allows our users to *also* pass optional `options.Mixpanel.peopleProperties` and `options.Mixpanel.superProperties arrays` in both `track` and `identify` calls that delineate which `.properties` or `.traits` fields respectively that they'd like to pass to which mixpanel API. This enables two new use cases in particular:

- Setting super properties on `track` calls (granularly to boot).
- Overriding default trait handling (sending all as both) and instead specifying which traits to set as super properties and which to set as people properties specifically.

The commit history here is a bit muddled as we balked on a prior implementation with similar goals that was erroneously merged to master and released (1.1.0).

Closes #9 @wcjohnson11 