### PR TITLE
adding check for no Mixpanel.superProperties object closes #11

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -151,7 +151,7 @@ Mixpanel.prototype.identify = function(identify) {
 
   // explicitly set select traits as people and super properties
   var opts = identify.integrations() || {};
-  opts = opts[this.name];
+  opts = opts[this.name] || {};
   var superProps = pick(opts.superProperties || [], traits);
   var peopleProps = pick(opts.peopleProperties || [], traits);
   if (!is.empty(superProps)) window.mixpanel.register(superProps);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -320,6 +320,11 @@ describe('Mixpanel', function() {
         analytics.called(window.mixpanel.people.set, { friend: 'elmo' });
       });
 
+      it('shouldn\'t try to register super properties if not specified', function() {
+        analytics.track('event', { friend: 'elmo' }, {});
+        analytics.didNotCall(window.mixpanel.register);
+      });
+
       it('should convert dates to iso strings', function() {
         var date = new Date();
         analytics.track('event', { date: date });


### PR DESCRIPTION
Added conditionals to make sure that a Mixpanel.superProperties || Mixpanel.superProperties object exists before trying to take the properties out of those objects.