### PR TITLE
fix multiple page call issue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -87,17 +87,24 @@ Mixpanel.prototype.loaded = function() {
 
 Mixpanel.prototype.page = function(page) {
   var category = page.category();
-  var name = page.fullName();
+  var name = page.name();
   var opts = this.options;
 
   // all pages
   if (opts.trackAllPages) {
     this.track(page.track());
+    return;
   }
 
   // categorized pages
-  if (category && opts.trackCategorizedPages) {
+  if (opts.trackCategorizedPages && category) {
+    // If this option is checked and name was also passed, used the full name which includes both category & name
+    if (name) {
+      this.track(page.track(page.fullName()));
+      return;
+    }
     this.track(page.track(category));
+    return;
   }
 
   // named pages

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -44,7 +44,8 @@ describe('Mixpanel', function() {
       .option('trackAllPages', false)
       .option('persistence', 'cookie')
       .option('trackNamedPages', true)
-      .option('setAllTraitsByDefault', true));
+      .option('setAllTraitsByDefault', true)
+      .option('trackCategorizedPages', true));
   });
 
   describe('before loading', function() {
@@ -117,7 +118,10 @@ describe('Mixpanel', function() {
 
       it('should track categorized pages by default', function() {
         analytics.page('Category', 'Name');
-        analytics.called(window.mixpanel.track, 'Viewed Category Page');
+        // This test was incorrectly testing this before, as it was passing based on the multiple call sending bug. The correct new call would be the following as noted in our docs:
+        analytics.called(window.mixpanel.track, 'Viewed Category Name Page');
+        analytics.didNotCall(window.mixpanel.track, 'Viewed Category Page');
+        analytics.didNotCall(window.mixpanel.track, 'Viewed Name Page');
       });
 
       it('should not track category pages when the option is off', function() {
@@ -134,6 +138,14 @@ describe('Mixpanel', function() {
         analytics.page('Name');
         analytics.called(window.mixpanel.track, 'Viewed Name Page');
         analytics.didNotCall(window.mixpanel.people.set, { $name: 'Name' });
+      });
+
+      it('should not send multiple page calls', function() {
+        mixpanel.options.trackAllPages = true;
+        mixpanel.options.trackNamedPages = true;
+        analytics.page('Teemo');
+        analytics.called(window.mixpanel.track, 'Loaded a Page');
+        analytics.didNotCall(window.mixpanel.track, 'Viewed Teemo Page');
       });
     });
 


### PR DESCRIPTION
@f2prateek can you check this? I followed your guideline from https://segment.phacility.com/T884

the previous tests for this was incorrectly testing the behavior behind when you call `analytics.page('category', 'name')` by checking that it called `Viewed Category Page`. It was passing because we were making extra calls and the `trackAllPages` block would use the `fullName()` which includes both name and category. 

Now, even if you have both track category and named pages enabled (which it is by default), if you pass both category and name, it will respect both and combine the two as we have said in our docs. 

If you have track category enabled and only pass category, we would just send `Viewed Category Page`. 