### PR TITLE
update default settings and add consolidated pages logic

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,9 +31,10 @@ var Mixpanel = module.exports = integration('Mixpanel')
   .option('people', false)
   .option('token', '')
   .option('setAllTraitsByDefault', true)
+  .option('consolidatedPageCalls', true)
   .option('trackAllPages', false)
-  .option('trackNamedPages', true)
-  .option('trackCategorizedPages', true)
+  .option('trackNamedPages', false)
+  .option('trackCategorizedPages', false)
   .tag('<script src="//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js">');
 
 /**
@@ -89,6 +90,12 @@ Mixpanel.prototype.page = function(page) {
   var category = page.category();
   var name = page.name();
   var opts = this.options;
+
+  // consolidated Page Calls
+  if (opts.consolidatedPageCalls) {
+    this.track(page.track());
+    return;
+  }
 
   // all pages
   if (opts.trackAllPages) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -13,7 +13,10 @@ describe('Mixpanel', function() {
     token: 'x',
     cookieName: 'y',
     crossSubdomainCookie: true,
-    secureCookie: true
+    secureCookie: true,
+    consolidatedPageCalls: false,
+    trackCategorizedPages: true,
+    trackNamedPages: true
   };
 
   beforeEach(function() {
@@ -43,9 +46,10 @@ describe('Mixpanel', function() {
       .option('token', '')
       .option('trackAllPages', false)
       .option('persistence', 'cookie')
-      .option('trackNamedPages', true)
+      .option('trackNamedPages', false)
+      .option('consolidatedPageCalls', true)
       .option('setAllTraitsByDefault', true)
-      .option('trackCategorizedPages', true));
+      .option('trackCategorizedPages', false));
   });
 
   describe('before loading', function() {
@@ -143,6 +147,14 @@ describe('Mixpanel', function() {
       it('should not send multiple page calls', function() {
         mixpanel.options.trackAllPages = true;
         mixpanel.options.trackNamedPages = true;
+        analytics.page('Teemo');
+        analytics.called(window.mixpanel.track, 'Loaded a Page');
+        analytics.didNotCall(window.mixpanel.track, 'Viewed Teemo Page');
+      });
+
+      // consolidatedPageCalls = true
+      it('should not send multiple page calls', function() {
+        mixpanel.options.consolidatedPageCalls = true;
         analytics.page('Teemo');
         analytics.called(window.mixpanel.track, 'Loaded a Page');
         analytics.didNotCall(window.mixpanel.track, 'Viewed Teemo Page');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -156,7 +156,14 @@ describe('Mixpanel', function() {
       it('should not send multiple page calls', function() {
         mixpanel.options.consolidatedPageCalls = true;
         analytics.page('Teemo');
-        analytics.called(window.mixpanel.track, 'Loaded a Page');
+        analytics.called(window.mixpanel.track, 'Loaded a Page', {
+          name: 'Teemo',
+          path: '/test/',
+          referrer: '',
+          search: '',
+          title: 'integrations tests',
+          url: window.location.href
+        });
         analytics.didNotCall(window.mixpanel.track, 'Viewed Teemo Page');
       });
     });


### PR DESCRIPTION
This PR adds support for the `consolidatedPageCalls` setting and changes the default settings in the integration.

This will help us migrate users to how Mixpanel suggests sending Page events, with one consolidated page event that includes properties to differentiate them.