### PR TITLE
tag mp_lib with Segment: web

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -63,6 +63,10 @@ Mixpanel.prototype.initialize = function() {
   /* eslint-enable */
   this.options.increments = lowercase(this.options.increments);
   var options = alias(this.options, optionsAliases);
+  // tag ajs requests with Segment by request from Mixpanel team for better mutual debugging
+  options.loaded = function(mixpanel) {
+    mixpanel.register({ mp_lib: 'Segment: web' });
+  };
   window.mixpanel.init(options.token, options);
   this.load(this.ready);
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -94,6 +94,14 @@ describe('Mixpanel', function() {
       analytics.page();
     });
 
+    describe('config', function() {
+      it('should tag mp_lib as Segment: web', function() {
+        analytics.initialize();
+        analytics.page();
+        analytics.assert(window.mixpanel.config.loaded.toString().slice(98, -2), 'mixpanel.register({"mp_lib":"Segment: web"})');
+      });
+    });
+
     describe('#page', function() {
       beforeEach(function() {
         analytics.stub(window.mixpanel, 'track');
@@ -160,9 +168,9 @@ describe('Mixpanel', function() {
         analytics.called(window.mixpanel.track, 'Loaded a Page', {
           name: 'Teemo',
           path: '/context.html',
-          referrer: document.referrer, 
+          referrer: document.referrer,
           search: '',
-          title: document.title, 
+          title: document.title,
           url: window.location.href
         });
         analytics.didNotCall(window.mixpanel.track, 'Viewed Teemo Page');


### PR DESCRIPTION
This resolves: https://segment.atlassian.net/browse/INT-521

Per request from Mixpanel team since our server side repo tags all events with `Segment - library name`, they want us to also tag `analytics.js` events with `Segment: web` to better assist during mutual debugging.

the test is a little jank because the option is a function so i had to stringify and slice it to assert that it passed the right function.

Can't stub `window.mixpanel.init` to check params because it is called inside our `initialize` function and I can't stub `window.mixpanel` before `analytics.initialize()` in the test file because `window.mixpanel` doesn't exist yet. 

@sperand-io @jgershen would be nice to have some api with our tester that let's us test functions inside initialize a little easier.
