### PR TITLE
Parity rewrite

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,8 @@ var indexOf = require('component-indexof');
 
 var Mixpanel = module.exports = integration('Mixpanel')
   .global('mixpanel')
-  .option('increments', [])
+  .option('eventIncrements', [])
+  .option('propIncrements', [])
   .option('peopleProperties', [])
   .option('superProperties', [])
   .option('cookieName', '')
@@ -63,7 +64,8 @@ Mixpanel.prototype.initialize = function() {
 0)))}}var d=a;"undefined"!==typeof f?d=a[f]=[]:f="mixpanel";d.people=d.people||[];d.toString=function(b){var a="mixpanel";"mixpanel"!==f&&(a+="."+f);b||(a+=" (stub)");return a};d.people.toString=function(){return d.toString(1)+".people (stub)"};k="disable time_event track track_pageview track_links track_forms register register_once alias unregister identify name_tag set_config reset people.set people.set_once people.increment people.append people.union people.track_charge people.clear_charges people.delete_user".split(" ");
 for(h=0;h<k.length;h++)e(d,k[h]);a._i.push([b,c,f])};a.__SV=1.2;}})(document,window.mixpanel||[]);
   /* eslint-enable */
-  this.options.increments = lowercase(this.options.increments);
+  this.options.eventIncrements = lowercase(this.options.eventIncrements);
+  this.options.propIncrements = lowercase(this.options.propIncrements);
   var options = alias(this.options, optionsAliases);
   // tag ajs requests with Segment by request from Mixpanel team for better mutual debugging
   options.loaded = function(mixpanel) {
@@ -169,22 +171,48 @@ Mixpanel.prototype.identify = function(identify) {
   var nametag = email || username || id;
   if (nametag) window.mixpanel.name_tag(nametag);
 
-  // default set all traits as super and people properties
   var traits = identify.traits(traitAliases);
   if (traits.$created) del(traits, 'createdAt');
-  if (setAllTraitsByDefault) {
-    window.mixpanel.register(dates(traits, iso));
-    if (this.options.people) window.mixpanel.people.set(traits);
+  traits = dates(traits, iso);
+
+  // determine which traits to union to existing properties and which to set as new properties
+  var traitsToUnion = {};
+  var traitsToSet = {};
+  for (var key in traits) {
+    if (!traits.hasOwnProperty(key)) continue;
+
+    var trait = traits[key];
+    if (Array.isArray(trait) && trait.length > 0) {
+      traitsToUnion[key] = trait;
+      // since mixpanel doesn't offer a union method for super properties we have to do it manually by retrieving the existing list super property 
+      // from mixpanel and manually unioning to it ourselves
+      var existingTrait = window.mixpanel.get_property(key);
+      if (existingTrait && Array.isArray(existingTrait)) {
+        traits[key] = unionArrays(existingTrait, trait);
+      }
+    } else {
+      traitsToSet[key] = trait;
+    }
   }
 
-  // explicitly set select traits as people and super properties
-  var mappedSuperProps = mapTraits(superProperties);
-  var superProps = pick(mappedSuperProps || [], traits);
-  if (!is.empty(superProps)) window.mixpanel.register(superProps);
-  if (people) {
-    var mappedPeopleProps = mapTraits(peopleProperties);
-    var peopleProps = pick(mappedPeopleProps || [], traits);
-    if (!is.empty(peopleProps)) window.mixpanel.people.set(peopleProps);
+  if (setAllTraitsByDefault) {
+    window.mixpanel.register(traits);
+    if (people) {
+      window.mixpanel.people.set(traitsToSet);
+      window.mixpanel.people.union(traitsToUnion);
+    }
+  } else {
+    // explicitly set select traits as people and super properties
+    var mappedSuperProps = mapTraits(superProperties);
+    var superProps = pick(mappedSuperProps || [], traits);
+    if (!is.empty(superProps)) window.mixpanel.register(superProps);
+    if (people) {
+      var mappedPeopleProps = mapTraits(peopleProperties);
+      var peoplePropsToSet = pick(mappedPeopleProps || [], traitsToSet);
+      var peoplePropsToUnion = pick(mappedPeopleProps || [], traitsToUnion);
+      if (!is.empty(peoplePropsToSet)) window.mixpanel.people.set(peoplePropsToSet);
+      if (!is.empty(peoplePropsToUnion)) window.mixpanel.people.union(peoplePropsToUnion);
+    }
   }
 };
 
@@ -199,8 +227,9 @@ Mixpanel.prototype.identify = function(identify) {
  */
 
 Mixpanel.prototype.track = function(track) {
-  var increments = this.options.increments;
-  var increment = track.event().toLowerCase();
+  var eventIncrements = this.options.eventIncrements;
+  var propIncrements = this.options.propIncrements;
+  var eventLowercase = track.event().toLowerCase();
   var people = this.options.people;
   var props = track.properties();
   var revenue = track.revenue();
@@ -214,13 +243,31 @@ Mixpanel.prototype.track = function(track) {
   delete props.mp_note;
   delete props.token;
 
-  // increment properties in mixpanel people
-  if (people && includes(increment, increments)) {
-    window.mixpanel.people.increment(track.event());
-    window.mixpanel.people.set('Last ' + track.event(), new Date());
-  }
-
   props = dates(props, iso);
+  invertObjLists(props);
+
+  // Mixpanel People operations
+  if (people) {
+    // increment event count
+    if (includes(eventLowercase, eventIncrements)) {
+      window.mixpanel.people.increment(track.event());
+      window.mixpanel.people.set('Last ' + track.event(), new Date());
+    }
+    // increment property counts
+    for (var key in props) {
+      if (!Object.prototype.hasOwnProperty.call(props, key)) {
+        continue;
+      }
+      var prop = props[key];
+      if (includes(key.toLowerCase(), propIncrements)) {
+        window.mixpanel.people.increment(key, prop);
+      }
+    }
+    // track revenue
+    if (revenue) {
+      window.mixpanel.people.track_charge(revenue);
+    }
+  }
 
   // track the event
   var query;
@@ -239,11 +286,6 @@ Mixpanel.prototype.track = function(track) {
   // register super properties if present in context.mixpanel.superProperties
   if (!is.empty(superProps)) {
     window.mixpanel.register(superProps);
-  }
-
-  // track revenue specifically
-  if (revenue && people) {
-    window.mixpanel.people.track_charge(revenue);
   }
 };
 
@@ -332,4 +374,75 @@ function extendTraits(arr) {
   }
 
   return arr;
+}
+
+/**
+ * Since Mixpanel doesn't support lists of objects, invert each list of objects to a set of lists of object properties.
+ * Treats list transformation atomically, e.g. will only transform if EVERY item in list is an object
+ *
+ * @api private
+ * @param {Object} props
+ * @example 
+ * input: {products: [{sku: 32, revenue: 99}, {sku:2, revenue: 103}]}
+ * output: {products_skus: [32, 2], products_revenues: [99, 103]}
+ */
+
+function invertObjLists(props) {
+  for (var propKey in props) {  // eslint-disable-line
+    var prop = props[propKey];
+    if (!props.hasOwnProperty(propKey) || !Array.isArray(prop)) {
+      continue;
+    }
+    var invertedLists = {};       
+    var listContainsNonObject = false;
+
+    // invert object lists and collect into invertedLists
+    for (var i=0; i<prop.length; i++) {
+      var elem = prop[i];
+      if (typeof elem !== 'object') {
+        listContainsNonObject = true;
+        break;
+      }
+      for (var key in elem) {
+        if (!elem.hasOwnProperty(key)) {
+          continue;
+        }
+        var attrKey = propKey+'_'+key+'s';  // e.g. products_skus
+        if (attrKey in invertedLists) {
+          invertedLists[attrKey].push(elem[key]);
+        } else {
+          invertedLists[attrKey] = [elem[key]];
+        }
+      }
+    }
+
+    // merge invertedLists with list
+    if (!listContainsNonObject) {
+      for (var listName in invertedLists) {
+        if (invertedLists.hasOwnProperty(listName)) {
+          var invertedList = invertedLists[listName];
+          props[listName] = listName in props ? props[listName].concat(invertedList) : invertedList;
+        }
+      }
+      delete props[propKey];
+    }
+  }
+}
+
+function unionArrays(x, y) {
+  var obj = {};
+  var i;
+  for (i = x.length-1; i >= 0; -- i) {
+    obj[x[i]] = x[i];
+  }
+  for (i = y.length-1; i >= 0; -- i) {
+    obj[y[i]] = y[i];
+  }
+  var res = [];
+  for (var k in obj) {
+    if (obj.hasOwnProperty(k)) {
+      res.push(obj[k]);
+    }
+  }
+  return res;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -267,10 +267,6 @@ Mixpanel.prototype.alias = function(alias) {
   mp.alias(to, alias.from());
 };
 
-Mixpanel.prototype.reset = function() {
-  window.mixpanel.reset();
-};
-
 /**
  * Lowercase the given `arr`.
  *

--- a/lib/index.js
+++ b/lib/index.js
@@ -220,9 +220,21 @@ Mixpanel.prototype.track = function(track) {
     window.mixpanel.people.set('Last ' + track.event(), new Date());
   }
 
-  // track the event
   props = dates(props, iso);
-  window.mixpanel.track(track.event(), props);
+
+  // track the event
+  var query;
+  if (props.link_query) {
+    query = props.link_query; // DOM query
+    delete props.link_query;
+    window.mixpanel.track_links(query, track.event(), props);
+  } else if (props.form_query) {  // DOM query
+    query = props.form_query;
+    delete props.form_query;
+    window.mixpanel.track_forms(query, track.event(), props);
+  } else {
+    window.mixpanel.track(track.event(), props);
+  }
 
   // register super properties if present in context.mixpanel.superProperties
   if (!is.empty(superProps)) {
@@ -253,6 +265,10 @@ Mixpanel.prototype.alias = function(alias) {
   if (mp.get_property && mp.get_property('$people_distinct_id') === to) return;
   // although undocumented, mixpanel takes an optional original id
   mp.alias(to, alias.from());
+};
+
+Mixpanel.prototype.reset = function() {
+  window.mixpanel.reset();
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -227,7 +227,7 @@ Mixpanel.prototype.identify = function(identify) {
  */
 
 Mixpanel.prototype.track = function(track) {
-  var eventIncrements = this.options.eventIncrements;
+  var eventIncrements = this.options.eventIncrements || this.options.increments; // TODO: remove settings.increments check, it's only here as we cutover from increments to eventIncrements
   var propIncrements = this.options.propIncrements;
   var eventLowercase = track.event().toLowerCase();
   var people = this.options.people;

--- a/lib/index.js
+++ b/lib/index.js
@@ -244,7 +244,7 @@ Mixpanel.prototype.track = function(track) {
   delete props.token;
 
   props = dates(props, iso);
-  invertObjLists(props);
+  invertObjectArrays(props);
 
   // Mixpanel People operations
   if (people) {
@@ -387,62 +387,81 @@ function extendTraits(arr) {
  * output: {products_skus: [32, 2], products_revenues: [99, 103]}
  */
 
-function invertObjLists(props) {
-  for (var propKey in props) {  // eslint-disable-line
-    var prop = props[propKey];
-    if (!props.hasOwnProperty(propKey) || !Array.isArray(prop)) {
+function invertObjectArrays(props) {
+  for (var propName in props) {  // eslint-disable-line
+    var propValue = props[propName];
+    if (!props.hasOwnProperty(propName) || !Array.isArray(propValue)) {
       continue;
     }
-    var invertedLists = {};       
-    var listContainsNonObject = false;
 
-    // invert object lists and collect into invertedLists
-    for (var i=0; i<prop.length; i++) {
-      var elem = prop[i];
-      if (typeof elem !== 'object') {
-        listContainsNonObject = true;
-        break;
-      }
-      for (var key in elem) {
-        if (!elem.hasOwnProperty(key)) {
-          continue;
-        }
-        var attrKey = propKey+'_'+key+'s';  // e.g. products_skus
-        if (attrKey in invertedLists) {
-          invertedLists[attrKey].push(elem[key]);
-        } else {
-          invertedLists[attrKey] = [elem[key]];
-        }
-      }
-    }
-
-    // merge invertedLists with list
-    if (!listContainsNonObject) {
-      for (var listName in invertedLists) {
-        if (invertedLists.hasOwnProperty(listName)) {
-          var invertedList = invertedLists[listName];
-          props[listName] = listName in props ? props[listName].concat(invertedList) : invertedList;
-        }
-      }
-      delete props[propKey];
+    var invertedArrays = invertObjectArray(propName, propValue);
+    if (Object.keys(invertedArrays).length !== 0) { // make sure obj isn't empty
+      mergeArraysIntoObj(props, invertedArrays);
+      delete props[propName];
     }
   }
 }
 
-function unionArrays(x, y) {
-  var obj = {};
-  var i;
-  for (i = x.length-1; i >= 0; -- i) {
-    obj[x[i]] = x[i];
-  }
-  for (i = y.length-1; i >= 0; -- i) {
-    obj[y[i]] = y[i];
-  }
-  var res = [];
-  for (var k in obj) {
-    if (obj.hasOwnProperty(k)) {
-      res.push(obj[k]);
+// Example:
+// input: 'products', [{sku: 32, revenue: 99}, {sku:2, revenue: 103}]
+// output: {products_skus: [32, 2], products_revenues: [99, 103]}
+function invertObjectArray(propName, arr) {
+  var invertedArrays = {};
+
+  // invert object lists and collect into invertedLists
+  for (var i=0; i<arr.length; i++) {
+    var elem = arr[i];
+
+    // abort operation if non-object encountered in array
+    if (typeof elem !== 'object') {
+      return {};
+    }
+    for (var key in elem) {
+      if (!elem.hasOwnProperty(key)) {
+        continue;
+      }
+      var attrKey = propName+'_'+key+'s';  // e.g. products_skus
+      
+      // append to list if it exists or create new one if not
+      if (attrKey in invertedArrays) {
+        invertedArrays[attrKey].push(elem[key]);
+      } else {
+        invertedArrays[attrKey] = [elem[key]];
+      }
     }
   }
-  return res;
+  return invertedArrays;
+}
+
+function mergeArraysIntoObj(destination, source) {
+  for (var arrayName in source) {
+    if (source.hasOwnProperty(arrayName)) {
+      var arr = source[arrayName];
+      destination[arrayName] = arrayName in destination ? destination[arrayName].concat(arr) : arr;
+    }
+  }
+}
+
+
+/**
+ * Return union of two arrays
+ * Pulled from https://stackoverflow.com/a/3629861
+ *
+ * @param {Array} x
+ * @param {Array} y
+ * @return {Array} res
+ * @api private
+ */
+
+function unionArrays(x, y) {
+  var obj = {};
+  // store items of each array as keys/values of obj, implicitly overwriting duplicates
+  var i;
+  for (i = 0; i < x.length; i++) {
+    obj[x[i]] = x[i];
+  }
+  for (i = 0; i < y.length; i++) {
+    obj[y[i]] = y[i];
+  }
+  return Object.keys(obj);
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@ndhoule/pick": "^2.0.0",
     "@segment/alias": "^1.0.1",
     "@segment/analytics.js-integration": "^2.1.0",
-    "@segment/convert-dates": "^1.0.0",
+    "@segment/convert-dates": "^1.1.0",
     "@segment/to-iso-string": "^1.0.1",
     "component-indexof": "0.0.3",
     "is": "^3.1.0",


### PR DESCRIPTION
This is the parity rewrite for Mixpanel. The following features are covered:

- Support unioning (append without duplicates) to Mixpanel People Properties and Super Properties
- Support incrementing at the property level (previously only supported at the event level) https://segment.atlassian.net/browse/PLATFORM-8
- Inverts object list properties to a format more readily analyzable by Mixpanel https://segment.atlassian.net/browse/PLATFORM-100