### PR TITLE
Fix flaky test.

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -448,7 +448,7 @@ describe('Mixpanel', function() {
         mixpanel.options.people = true;
         analytics.track('event');
         var date = window.mixpanel.people.set.args[0][1];
-        analytics.assert(date.getTime() === new Date().getTime());
+        analytics.assert(new Date().getTime() - date.getTime() < 1000);
         analytics.called(window.mixpanel.people.increment, 'event');
         analytics.called(window.mixpanel.people.set, 'Last event', date);
       });
@@ -488,7 +488,7 @@ describe('Mixpanel', function() {
         mixpanel.options.propIncrements = ['videos_watched'];
         mixpanel.options.people = true;
         analytics.track('event', {
-          videos_watched: 3 
+          videos_watched: 3
         });
         analytics.called(window.mixpanel.people.increment, 'videos_watched', 3);
       });


### PR DESCRIPTION
This integration has had flaky builds while building in Circle CI. 

The failure would occur in
> Mixpanel after loading #track should should update people property if the event is in .increments FAILED

Logging `false == true` in this [test](https://github.com/segment-integrations/analytics.js-integration-mixpanel/blob/master/test/index.test.js#L451).

The test is verifying that the last seen date is set properly. When console.logging the output of `getTime`, you can see why the test is flaky:

```        console.log(date.getTime());
        console.log(new Date().getTime());

       ✗ should should update people property if the event is in .increments
    false == true
LOG LOG: 1531869660110
LOG LOG: 1531869660111
```

They are a milisecond off, thus the `false == true` assertion. You can see historically that rebuilding multiple times would eventually have the test passing, betting on the potential methods capturing the same time. If you look at the[ historical builds on `master` in CI](https://circleci.com/gh/segment-integrations/analytics.js-integration-mixpanel/tree/master), you can see the failure occurred in the same place.

This fix is to mitigate the flaky test, and will assert that the integration is using the correct date with some level of tolerance (a second in this case).