### PR TITLE
Add/setting source name

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,8 +4,6 @@ machine:
   environment:
     NPM_CONFIG_PROGRESS: false
     NPM_CONFIG_SPIN: false
-    SAUCE_ACCESS_KEY: 80dcffc2-c9a2-45e2-9fb7-87b29a6cd986
-    SAUCE_USERNAME: segment-oss
     TEST_REPORTS_DIR: $CIRCLE_TEST_REPORTS
 
 dependencies:

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,7 @@ var Mixpanel = module.exports = integration('Mixpanel')
   .option('trackAllPages', false)
   .option('trackNamedPages', false)
   .option('trackCategorizedPages', false)
+  .option('sourceName', '')
   .tag('<script src="//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js">');
 
 /**
@@ -184,7 +185,7 @@ Mixpanel.prototype.identify = function(identify) {
     var trait = traits[key];
     if (Array.isArray(trait) && trait.length > 0) {
       traitsToUnion[key] = trait;
-      // since mixpanel doesn't offer a union method for super properties we have to do it manually by retrieving the existing list super property 
+      // since mixpanel doesn't offer a union method for super properties we have to do it manually by retrieving the existing list super property
       // from mixpanel and manually unioning to it ourselves
       var existingTrait = window.mixpanel.get_property(key);
       if (existingTrait && Array.isArray(existingTrait)) {
@@ -235,6 +236,9 @@ Mixpanel.prototype.track = function(track) {
   var revenue = track.revenue();
   // Don't map traits, clients should use identify instead.
   var superProps = pick(this.options.superProperties, props);
+  var sourceName = this.options.sourceName;
+
+  if (sourceName) props.segment_source_name = sourceName;
 
   // delete mixpanel's reserved properties, so they don't conflict
   delete props.distinct_id;
@@ -382,7 +386,7 @@ function extendTraits(arr) {
  *
  * @api private
  * @param {Object} props
- * @example 
+ * @example
  * input: {products: [{sku: 32, revenue: 99}, {sku:2, revenue: 103}]}
  * output: {products_skus: [32, 2], products_revenues: [99, 103]}
  */
@@ -421,7 +425,7 @@ function invertObjectArray(propName, arr) {
         continue;
       }
       var attrKey = propName+'_'+key+'s';  // e.g. products_skus
-      
+
       // append to list if it exists or create new one if not
       if (attrKey in invertedArrays) {
         invertedArrays[attrKey].push(elem[key]);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -50,7 +50,8 @@ describe('Mixpanel', function() {
       .option('trackNamedPages', false)
       .option('consolidatedPageCalls', true)
       .option('setAllTraitsByDefault', true)
-      .option('trackCategorizedPages', false));
+      .option('trackCategorizedPages', false)
+      .option('sourceName', ''));
   });
 
   describe('before loading', function() {
@@ -491,6 +492,16 @@ describe('Mixpanel', function() {
           videos_watched: 3
         });
         analytics.called(window.mixpanel.people.increment, 'videos_watched', 3);
+      });
+
+      it('should send sourceName if specified', function() {
+        mixpanel.options.sourceName = 'ios_prod';
+        analytics.track('event', {
+          segment_source_name: 'ios_prod'
+        });
+        analytics.called(window.mixpanel.track, 'event', {
+          segment_source_name: 'ios_prod'
+        });
       });
     });
 


### PR DESCRIPTION
Millicom asked us to add a custom "segment_source_name" property to our client and serverside Mixpanel integrations. Today, this feature only works for the server-side Mixpanel integration. 

The changes introduced will support sending a property called `segment_source_name` to Mixpanel on a Segment `track` event when a user has the setting `sourceName` configured with a value in Segment's UI. This brings the client and [server-side Mixpanel integrations](https://github.com/segmentio/integrations/blob/f5820ec658a6724dd79a86e382aad9678b9cdf55/integrations/mixpanel/lib/index.js#L493) to parity with regards to this setting.

Tested locally with [golden-compiler](https://github.com/segmentio/golden-compiler)
Steps taken:

1. Install tool with `npm install -g @segment/golden-compiler`
2. Create settings.json and add the following
```
{
  "Mixpanel":{
    "consolidatedPageCalls":true,
    "crossSubdomainCookie":true,
    "eventIncrements":[],
    "legacySuperProperties":false,
    "people":false,
    "peopleProperties":[],
    "persistence":"cookie",
    "propIncrements":[],
    "secureCookie":false,
    "setAllTraitsByDefault":true,
    "sourceName":"my_source",
    "superProperties":[],
    "token":"<YOUR TOKEN>",
    "trackAllPages":false,
    "trackCategorizedPages":false,
    "trackNamedPages":false}
}
```
3. Enable Mixpanel in a sample workspace/source
4. Add value to the setting `sourceName`, in this case I added `my_source`.
5. Using the relevant writeKey, run: `golden-ajs --settings= ./settings.json --slug=mixpanel --write-key=<WRITE_KEY>`
6. Open localhost:8080
7. See the local version of AJS loaded with your updates in the source tab
8. In the console, trigger a `track` call
9. See the request go to Mixpanel in the network tab
10. See the `source_name` appear in Mixpanel's UI as a property

![screenshot 2018-07-17 16 13 00](https://user-images.githubusercontent.com/7421111/42899344-9c974bbe-8a7a-11e8-99d3-fe6699360706.png)


JIRA ticket: https://segment.atlassian.net/browse/ENT-97
CC ticket: https://segment.atlassian.net/browse/CC-922

**Note:** The sauce lab keys are removed here because the ENV variables are respected and set via Circle CI's UI, not the circle.yml. In addition to this, we should not put credentials in open sourced repos. Confirmed that these credentials removed are expired and no longer used in production.