### PR TITLE
Map CapitalCase special properties to mixpanel

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -142,7 +142,15 @@ var traitAliases = {
   lastSeen: '$last_seen',
   name: '$name',
   username: '$username',
-  phone: '$phone'
+  phone: '$phone',
+  Created: '$created',
+  Email: '$email',
+  FirstName: '$first_name',
+  LastName: '$last_name',
+  LastSeen: '$last_seen',
+  Name: '$name',
+  Username: '$username',
+  Phone: '$phone'
 };
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -297,6 +297,30 @@ describe('Mixpanel', function() {
         });
       });
 
+      it('should alias CapitalCase traits', function() {
+        var date = new Date();
+        analytics.identify({
+          Created: date,
+          Email: 'name@example.com',
+          FirstName: 'first',
+          LastName: 'last',
+          LastSeen: date,
+          Name: 'name',
+          Username: 'username',
+          Phone: 'phone'
+        });
+        analytics.called(window.mixpanel.register, {
+          $created: iso(date),
+          $email: 'name@example.com',
+          $first_name: 'first',
+          $last_name: 'last',
+          $last_seen: iso(date),
+          $name: 'name',
+          $username: 'username',
+          $phone: 'phone'
+        });
+      });
+
       it('should alias traits to Mixpanel People', function() {
         mixpanel.options.people = true;
         var date = new Date();
@@ -309,6 +333,31 @@ describe('Mixpanel', function() {
           name: 'name',
           username: 'username',
           phone: 'phone'
+        });
+        analytics.called(window.mixpanel.people.set, {
+          $created: iso(date),
+          $email: 'name@example.com',
+          $first_name: 'first',
+          $last_name: 'last',
+          $last_seen: iso(date),
+          $name: 'name',
+          $username: 'username',
+          $phone: 'phone'
+        });
+      });
+
+      it('should alias CapitalCase traits to Mixpanel People', function() {
+        mixpanel.options.people = true;
+        var date = new Date();
+        analytics.identify({
+          Created: date,
+          Email: 'name@example.com',
+          FirstName: 'first',
+          LastName: 'last',
+          LastSeen: date,
+          Name: 'name',
+          Username: 'username',
+          Phone: 'phone'
         });
         analytics.called(window.mixpanel.people.set, {
           $created: iso(date),


### PR DESCRIPTION
Previously only camel case special properties would map to their Mixpanel equivalents,
eg. "name" maps to "$name" and "email" to "$email".  This causes issues when a
CapitalCase trait naming convention is used.  This change allows for all special properties
to be properly mapped to their Mixpanel equivalents, eg. "Name" to "$name" and "Email"
to "$email".